### PR TITLE
support caching and debugging

### DIFF
--- a/src/ScriptCs.CSharp/CSharpModule.cs
+++ b/src/ScriptCs.CSharp/CSharpModule.cs
@@ -13,7 +13,8 @@ namespace ScriptCs.CSharp
                 throw new ArgumentNullException("config");
             }
 
-            var engineType = config.IsRepl ? typeof (CSharpReplEngine) : typeof (CSharpScriptEngine);
+            var engineType = config.Debug ? typeof(CSharpScriptInMemoryEngine) : typeof(CSharpScriptEngine);
+            engineType = config.IsRepl ? typeof (CSharpReplEngine) : engineType;
             config.Overrides[typeof(IScriptEngine)] = engineType;
         }
     }

--- a/src/ScriptCs.CSharp/CSharpModule.cs
+++ b/src/ScriptCs.CSharp/CSharpModule.cs
@@ -13,8 +13,9 @@ namespace ScriptCs.CSharp
                 throw new ArgumentNullException("config");
             }
 
-            var engineType = config.Debug ? typeof(CSharpScriptInMemoryEngine) : typeof(CSharpScriptEngine);
-            engineType = config.IsRepl ? typeof (CSharpReplEngine) : engineType;
+            var engineType = config.Cache ? typeof(CSharpPersistentEngine) : typeof(CSharpScriptEngine);
+            engineType = config.Debug ? typeof(CSharpScriptInMemoryEngine) : engineType;
+            engineType = config.IsRepl ? typeof(CSharpReplEngine) : engineType;
             config.Overrides[typeof(IScriptEngine)] = engineType;
         }
     }

--- a/src/ScriptCs.CSharp/CSharpPersistentEngine.cs
+++ b/src/ScriptCs.CSharp/CSharpPersistentEngine.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Common.Logging;
+using ScriptCs.Contracts;
+
+namespace ScriptCs.CSharp
+{
+    public class CSharpPersistentEngine : CSharpScriptCompilerEngine
+    {
+        private readonly IFileSystem _fileSystem;
+        private const string RoslynAssemblyNameCharacter = "ℛ";
+
+        public CSharpPersistentEngine(IScriptHostFactory scriptHostFactory, ILog logger, IFileSystem fileSystem)
+            : base(scriptHostFactory, logger)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        protected override bool ShouldCompile()
+        {
+            var dllPath = GetDllTargetPath();
+
+            return !_fileSystem.FileExists(dllPath);
+        }
+
+        protected override Assembly LoadAssembly(byte[] exeBytes, byte[] pdbBytes)
+        {
+            this.Logger.DebugFormat("Writing assembly to {0}.", FileName);
+
+            if (!_fileSystem.DirectoryExists(CacheDirectory))
+            {
+                _fileSystem.CreateDirectory(CacheDirectory, true);
+            }
+
+            var dllPath = GetDllTargetPath();
+            _fileSystem.WriteAllBytes(dllPath, exeBytes);
+
+            Logger.DebugFormat("Loading assembly {0}.", dllPath);
+
+            // the assembly is automatically loaded into the AppDomain when compiled
+            // just need to find and return it
+            return AppDomain.CurrentDomain.GetAssemblies().LastOrDefault(x => x.FullName.StartsWith(RoslynAssemblyNameCharacter));
+        }
+
+        protected override Assembly LoadAssemblyFromCache()
+        {
+            var dllPath = GetDllTargetPath();
+            return Assembly.LoadFrom(dllPath);
+        }
+
+        private string GetDllTargetPath()
+        {
+            var dllName = FileName.Replace(Path.GetExtension(FileName), ".dll");
+            var dllPath = Path.Combine(CacheDirectory, dllName);
+            return dllPath;
+        }
+    }
+}

--- a/src/ScriptCs.CSharp/CSharpScriptCompilerEngine.cs
+++ b/src/ScriptCs.CSharp/CSharpScriptCompilerEngine.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Common.Logging;
+using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.CodeAnalysis.Scripting.CSharp;
+using ScriptCs.Contracts;
+using ScriptCs.Engine.Common;
+using ScriptCs.Exceptions;
+
+namespace ScriptCs.CSharp
+{
+    public abstract class CSharpScriptCompilerEngine : CommonScriptEngine
+    {
+        private const string CompiledScriptClass = "Submission#0";
+
+        private const string CompiledScriptMethod = "<Factory>";
+
+        protected CSharpScriptCompilerEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+            : base(scriptHostFactory, logger)
+        {
+        }
+
+        protected abstract bool ShouldCompile();
+
+        protected abstract Assembly LoadAssembly(byte[] exeBytes, byte[] pdbBytes);
+
+        protected abstract Assembly LoadAssemblyFromCache();
+
+        protected override ScriptResult Execute(string code, object globals, SessionState<ScriptState> sessionState)
+        {
+            return ShouldCompile()
+                ? CompileAndExecute(code, globals)
+                : InvokeEntryPointMethod(globals, LoadAssemblyFromCache());
+        }
+
+        protected override ScriptState GetScriptState(string code, object globals)
+        {
+            return null;
+        }
+
+        protected ScriptResult CompileAndExecute(string code, object globals)
+        {
+            try
+            {
+                var script = CSharpScript.Create(code, ScriptOptions);
+                var compilation = script.GetCompilation();
+
+                using (var exeStream = new MemoryStream())
+                using (var pdbStream = new MemoryStream())
+                {
+                    var result = compilation.Emit(exeStream, pdbStream: pdbStream);
+
+                    if (result.Success)
+                    {
+                        Logger.Debug("Compilation was successful.");
+
+                        var assembly = LoadAssembly(exeStream.ToArray(), pdbStream.ToArray());
+                        return InvokeEntryPointMethod(globals, assembly);
+                    }
+
+                    var errors = string.Join(Environment.NewLine, result.Diagnostics.Select(x => x.ToString()));
+
+                    Logger.ErrorFormat("Error occurred when compiling: {0})", errors);
+
+                    return new ScriptResult(compilationException: new ScriptCompilationException(errors));
+                }
+            }
+            catch (Exception compileException)
+            {
+                //we catch Exception rather than CompilationErrorException because there might be issues with assembly loading too
+                return new ScriptResult(compilationException: new ScriptCompilationException(compileException.Message, compileException));
+            }
+        }
+
+        private ScriptResult InvokeEntryPointMethod(object globals, Assembly assembly)
+        {
+            Logger.Debug("Retrieving compiled script class (reflection).");
+
+            // the following line can throw NullReferenceException, if that happens it's useful to notify that an error ocurred
+            var type = assembly.GetType(CompiledScriptClass);
+            Logger.Debug("Retrieving compiled script method (reflection).");
+            var method = type.GetMethod(CompiledScriptMethod, BindingFlags.Static | BindingFlags.Public);
+
+            try
+            {
+                Logger.Debug("Invoking method.");
+                var submissionStates = new object[2];
+                submissionStates[0] = globals;
+                return new ScriptResult(returnValue: method.Invoke(null, new[] { submissionStates }));
+            }
+            catch (Exception executeException)
+            {
+                Logger.Error("An error occurred when executing the scripts.");
+
+                var ex = executeException.InnerException ?? executeException;
+
+                return new ScriptResult(executionException: ex);
+            }
+        }
+    }
+}

--- a/src/ScriptCs.CSharp/CSharpScriptInMemoryEngine.cs
+++ b/src/ScriptCs.CSharp/CSharpScriptInMemoryEngine.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reflection;
+using Common.Logging;
+using ScriptCs.Contracts;
+
+namespace ScriptCs.CSharp
+{
+    public class CSharpScriptInMemoryEngine : CSharpScriptCompilerEngine
+    {
+        public CSharpScriptInMemoryEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+            : base(scriptHostFactory, logger)
+        {
+        }
+
+        protected override bool ShouldCompile()
+        {
+            return true;
+        }
+
+        protected override Assembly LoadAssemblyFromCache()
+        {
+            throw new NotImplementedException("Reaching this point indicates a bug. The RoslynScriptInMemoryEngine should never load the assembly from the cache.");
+        }
+
+        protected override Assembly LoadAssembly(byte[] exeBytes, byte[] pdbBytes)
+        {
+            this.Logger.Debug("Loading assembly from memory.");
+
+            // this is required for debugging. otherwise, the .dll is not related to the .pdb
+            // there might be ways of doing this without "loading", haven't found one yet
+            return AppDomain.CurrentDomain.Load(exeBytes, pdbBytes);
+        }
+    }
+}

--- a/src/ScriptCs.CSharp/ScriptCs.CSharp.csproj
+++ b/src/ScriptCs.CSharp/ScriptCs.CSharp.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\scriptcs\src\Scriptcs\bin\debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -76,7 +76,9 @@
     </Compile>
     <Compile Include="CSharpModule.cs" />
     <Compile Include="CSharpReplEngine.cs" />
+    <Compile Include="CSharpScriptCompilerEngine.cs" />
     <Compile Include="CSharpScriptEngine.cs" />
+    <Compile Include="CSharpScriptInMemoryEngine.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ScriptCs.CSharp/ScriptCs.CSharp.csproj
+++ b/src/ScriptCs.CSharp/ScriptCs.CSharp.csproj
@@ -75,6 +75,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CSharpModule.cs" />
+    <Compile Include="CSharpPersistentEngine.cs" />
     <Compile Include="CSharpReplEngine.cs" />
     <Compile Include="CSharpScriptCompilerEngine.cs" />
     <Compile Include="CSharpScriptEngine.cs" />


### PR DESCRIPTION
Added:
- CSharpPersistentEngine
- CSharpScriptCompilerEngine
- CSharpScriptInMemoryEngine

This introduces support for both debugging and caching bringing us pretty much to feature parity (sans a few bugs I guess).
